### PR TITLE
refactor: support to workers send e-mails

### DIFF
--- a/examples/rabbitmq-worker/.mautic_env.example
+++ b/examples/rabbitmq-worker/.mautic_env.example
@@ -15,8 +15,8 @@ MAUTIC_MESSENGER_DSN_FAILED="amqp://${RABBITMQ_DEFAULT_USER}:${RABBITMQ_DEFAULT_
 # For example, to use the mailgun mailer, you would set the MAILER_URL as follows:
 # SMTP
 MAILGUN_SENDINGKEY="<YOUR SENDING KEY>" # e.g.: xxxxxxxx-xxxxxxx-xxxxxxx
-MAILGUN_DOMAIN="<YOUR DOMAIN>" # e.g.: sandboxxxxxxxxxxxxxx.mailgun.org
-MAILER_URL="mailgun+api://api:key-${MAILGUN_SENDINGKEY}@${MAILGUN_DOMAIN}"
+MAILGUN_DOMAIN="<YOUR MAILGUN DOMAIN>" # e.g.: sandboxxxxxxxxxxxxxx.mailgun.org. Get in https://app.mailgun.com/mg/sending/domains
+MAILER_URL="mailgun+api://api:key-${MAILGUN_SENDINGKEY}%%40$${MAILGUN_DOMAIN}"
 
 DOCKER_MAUTIC_RUN_MIGRATIONS=false
 DOCKER_MAUTIC_LOAD_TEST_DATA=false

--- a/examples/rabbitmq-worker/docker-compose.yml
+++ b/examples/rabbitmq-worker/docker-compose.yml
@@ -4,7 +4,6 @@ x-mautic-volumes: &mautic-volumes
   - ./volumes/mautic/logs:/var/www/html/var/logs:z
   - ./volumes/mautic/media/files:/var/www/html/docroot/media/files:z
   - ./volumes/mautic/media/images:/var/www/html/docroot/media/images:z
-  - ./volumes/mautic/cron:/opt/mautic/cron:z
   - ./mautic_web-entrypoint_custom.sh:/entrypoint_custom.sh
   - ./supervisord.conf:/etc/supervisor/conf.d/supervisord.conf
 services:
@@ -90,7 +89,12 @@ services:
 
   # Mautic Web Application
   mautic_web:
-    image: mautic/mautic:5.2.1-apache
+    depends_on:
+      db:
+        condition: service_healthy
+      rabbitmq:
+        condition: service_healthy
+    image: mautic/mautic:5.2.3-apache
     restart: unless-stopped
     links:
       - db:mysql
@@ -117,11 +121,6 @@ services:
       interval: 30s
       timeout: 10s
       retries: 3
-    depends_on:
-      db:
-        condition: service_healthy
-      rabbitmq:
-        condition: service_healthy
     networks:
       - mautic_network
     logging:
@@ -132,7 +131,7 @@ services:
 
   # Mautic Cron Service
   mautic_cron:
-    image: mautic/mautic:5.2.1-apache
+    image: mautic/mautic:5.2.3-apache
     restart: unless-stopped
     links:
       - db:mysql
@@ -164,7 +163,7 @@ services:
 
   # Mautic Worker Service
   mautic_worker:
-    image: mautic/mautic:5.2.1-apache
+    image: mautic/mautic:5.2.3-apache
     restart: unless-stopped
     links:
       - db:mysql

--- a/examples/rabbitmq-worker/rabbitmq-entrypoint_custom.sh
+++ b/examples/rabbitmq-worker/rabbitmq-entrypoint_custom.sh
@@ -7,21 +7,75 @@ if ! command -v curl &> /dev/null; then
   apt-get update && apt-get install -y curl
 fi
 
-rabbitmq-server &
+# Start RabbitMQ server in the background
+echo "Starting RabbitMQ server..."
+rabbitmq-server > /var/log/rabbitmq/rabbitmq.log 2>&1 &
+RABBITMQ_PID=$!
 
-# Additional health check using RabbitMQ management API
-until curl -s -o /dev/null -w "%{http_code}" http://localhost:15672/api/healthchecks/node | grep -q "200"; do
-  sleep 5
+# Function to check if RabbitMQ is fully operational
+check_rabbitmq() {
+    rabbitmqctl status >/dev/null 2>&1 && \
+    curl -s -u "${RABBITMQ_DEFAULT_USER}":"${RABBITMQ_DEFAULT_PASS}" http://localhost:15672/api/overview >/dev/null 2>&1
+}
+
+# Wait for RabbitMQ to be fully operational
+echo "Waiting for RabbitMQ to be fully operational..."
+TIMEOUT=180
+START_TIME=$(date +%s)
+
+until check_rabbitmq || [ $(($(date +%s) - $START_TIME)) -gt $TIMEOUT ]; do
+    echo "Waiting for RabbitMQ..."
+    sleep 5
 done
 
-# Create vhosts
-rabbitmqctl add_vhost "${RABBITMQ_MAIL_VHOST}"
-rabbitmqctl add_vhost "${RABBITMQ_HIT_VHOST}"
-rabbitmqctl add_vhost "${RABBITMQ_FAILED_VHOST}"
-rabbitmqctl set_permissions -p "${RABBITMQ_MAIL_VHOST}" "${RABBITMQ_DEFAULT_USER}" ".*" ".*" ".*"
-rabbitmqctl set_permissions -p "${RABBITMQ_HIT_VHOST}" "${RABBITMQ_DEFAULT_USER}" ".*" ".*" ".*"
-rabbitmqctl set_permissions -p "${RABBITMQ_FAILED_VHOST}" "${RABBITMQ_DEFAULT_USER}" ".*" ".*" ".*"
+if ! check_rabbitmq; then
+    echo "Error: RabbitMQ failed to start within ${TIMEOUT} seconds"
+    exit 1
+fi
+
+echo "RabbitMQ is up and running!"
+
+# Function to check if a vhost exists
+vhost_exists() {
+  vhost="$1"
+  rabbitmqctl list_vhosts | grep -q "^$vhost$"
+}
+
+# Create vhosts and set permissions
+echo "Creating RabbitMQ vhosts..."
+
+if ! vhost_exists "${RABBITMQ_MAIL_VHOST}"; then
+  rabbitmqctl add_vhost "${RABBITMQ_MAIL_VHOST}"
+  rabbitmqctl set_permissions -p "${RABBITMQ_MAIL_VHOST}" "${RABBITMQ_DEFAULT_USER}" ".*" ".*" ".*"
+  echo "Created vhost ${RABBITMQ_MAIL_VHOST} and set permissions."
+else
+  echo "Vhost ${RABBITMQ_MAIL_VHOST} already exists."
+fi
+
+if ! vhost_exists "${RABBITMQ_HIT_VHOST}"; then
+  rabbitmqctl add_vhost "${RABBITMQ_HIT_VHOST}"
+  rabbitmqctl set_permissions -p "${RABBITMQ_HIT_VHOST}" "${RABBITMQ_DEFAULT_USER}" ".*" ".*" ".*"
+    echo "Created vhost ${RABBITMQ_HIT_VHOST} and set permissions."
+else
+  echo "Vhost ${RABBITMQ_HIT_VHOST} already exists."
+fi
+
+if ! vhost_exists "${RABBITMQ_FAILED_VHOST}"; then
+  rabbitmqctl add_vhost "${RABBITMQ_FAILED_VHOST}"
+  rabbitmqctl set_permissions -p "${RABBITMQ_FAILED_VHOST}" "${RABBITMQ_DEFAULT_USER}" ".*" ".*" ".*"
+  echo "Created vhost ${RABBITMQ_FAILED_VHOST} and set permissions."
+else
+  echo "Vhost ${RABBITMQ_FAILED_VHOST} already exists."
+fi
+
+echo "RabbitMQ vhosts created/verified!"
 
 # Set correct permissions for RabbitMQ directories
 chown -R rabbitmq:rabbitmq /var/lib/rabbitmq
+echo "RabbitMQ directories permissions set!"
 
+echo "==============RabbitMQ setup complete!=============="
+
+tail -f /var/log/rabbitmq/rabbitmq.log &
+
+wait $RABBITMQ_PID

--- a/examples/rabbitmq-worker/supervisord.conf
+++ b/examples/rabbitmq-worker/supervisord.conf
@@ -7,6 +7,7 @@
 ; -b, --bus BUS:  The message bus to consume from.
 ; --queues QUEUES:  Define the queues from where to consume messages (comma separated).
 ; --no-reset:  Do not reset failed messages.
+; -vv: verbose mode
 ; <receivers>:  Specific receivers to consume from (e.g., "email", "hit", "failed").  If not specified, consumes from all configured receivers.
 ;
 ; Recommendations for resilience and performance:
@@ -23,67 +24,58 @@
 
 [supervisord]
 nodaemon=true                     ; Run supervisord in the foreground (not as a daemon)
-logfile=/var/log/supervisord.log  ; Supervisord log file
-logfile_maxbytes=10MB             ; Limit log file size
-logfile_backups=10                ; Rotate log files
+;logfile=/var/log/supervisord.log  ; Supervisord log file
+logfile=/dev/null
+;logfile_maxbytes=10MB             ; Limit log file size
+;logfile_backups=10                ; Rotate log files
 user=root                         ; Run supervisord as the root user
 
 [group:messenger] ; Define a group named 'messenger'
 programs=messenger-consume-email,messenger-consume-hit,messenger-consume-failed ; List the programs in the group
 
 [program:messenger-consume-email]
-command=php /var/www/html/bin/console messenger:consume email --limit 300 ; --failure-limit 5 --memory-limit 512 --time-limit 60   ; Command to execute
-user=www-data                                                 ; User to run the process as
-numprocs=%(ENV_DOCKER_MAUTIC_WORKERS_CONSUME_EMAIL)s          ; Number of processes to run (read from environment variable)
-startsecs=5                                                   ; Wait 5 second after process start
-autostart=true                                                ; Automatically start the process when supervisord starts
-autorestart=true                                              ; Automatically restart the process if it exits
-startretries=3                                                ; Number of times to retry starting the process
-process_name=%(program_name)s_%(process_num)02d               ; Name of the process (includes program name and process number)
-stdout_logfile=/var/log/messenger-consume-email.log           ; Dedicated log file
-stdout_logfile_maxbytes=10MB                                  ; Limit log file size
-stdout_logfile_backups=10                                     ; Rotate log files
-stderr_logfile=/var/log/messenger-consume-email-error.log     ; Separate error log
-stderr_logfile_maxbytes=10MB                                  ; Limit error log file size
-stderr_logfile_backups=10                                     ; Rotate error log files
-;resource_limits:cpu=20                                       ; Limit CPU usage to 20% (example)
-;resource_limits:memory=200MB                                 ; Limit memory usage to 200MB (example)
-redirect_stderr=false                                         ; Don't redirect stderr to stdout
+command=php /var/www/html/bin/console messenger:consume email -vv ; Command to execute - e.g: --limit 300 --failure-limit 5 --memory-limit 512 --time-limit 60
+user=www-data                                                     ; User to run the process as
+numprocs=%(ENV_DOCKER_MAUTIC_WORKERS_CONSUME_EMAIL)s              ; Number of processes to run (read from environment variable)
+startsecs=0                                                       ; Wait 5 second after process start
+autostart=true                                                    ; Automatically start the process when supervisord starts
+autorestart=true                                                  ; Automatically restart the process if it exits
+startretries=10                                                   ; Number of times to retry starting the process
+process_name=%(program_name)s_%(process_num)02d                   ; Name of the process (includes program name and process number)
+;stdout_logfile=/var/log/messenger-consume-email.log              ; Dedicated log file
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=10MB                                      ; Limit log file size
+stdout_logfile_backups=10                                         ; Rotate log files
+stdout_logfile_maxbytes=0                                         ; Log file size unlimited
+;stderr_logfile=/var/log/messenger-consume-email-error.log        ; Separate error log
+;stderr_logfile_maxbytes=10MB                                     ; Limit error log file size
+;stderr_logfile_backups=10                                        ; Rotate error log files
+;resource_limits:cpu=20                                           ; Limit CPU usage to 20% (example)
+;resource_limits:memory=200MB                                     ; Limit memory usage to 200MB (example)
+redirect_stderr=true                                              ; Redirect stderr to stdout
 
 [program:messenger-consume-hit]
-command=php /var/www/html/bin/console messenger:consume hit   ; Command to execute
-user=www-data                                                 ; User to run the process as
-numprocs=%(ENV_DOCKER_MAUTIC_WORKERS_CONSUME_HIT)s            ; Number of processes to run (read from environment variable)
-startsecs=5                                                   ; Wait 5 second after process start
-autostart=true                                                ; Automatically start the process when supervisord starts
-autorestart=true                                              ; Automatically restart the process if it exits
-startretries=3                                                ; Number of times to retry starting the process
-process_name=%(program_name)s_%(process_num)02d               ; Name of the process (includes program name and process number)
-stdout_logfile=/var/log/messenger-consume-hit.log             ; Dedicated log file
-stdout_logfile_maxbytes=10MB                                  ; Limit log file size
-stdout_logfile_backups=10                                     ; Rotate log files
-stderr_logfile=/var/log/messenger-consume-hit-error.log       ; Separate error log
-stderr_logfile_maxbytes=10MB                                  ; Limit error log file size
-stderr_logfile_backups=10                                     ; Rotate error log files
-;resource_limits:cpu=20                                       ; Limit CPU usage to 20% (example)
-;resource_limits:memory=200MB                                 ; Limit memory usage to 200MB (example)
-redirect_stderr=false                                         ; Don't redirect stderr to stdout
+command=php /var/www/html/bin/console messenger:consume hit -vv
+user=www-data
+numprocs=%(ENV_DOCKER_MAUTIC_WORKERS_CONSUME_HIT)s
+startsecs=0
+autostart=true
+autorestart=true
+startretries=10
+process_name=%(program_name)s_%(process_num)02d
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+redirect_stderr=true
 
 [program:messenger-consume-failed]
-command=php /var/www/html/bin/console messenger:consume failed  ; Command to execute
-user=www-data                                                   ; User to run the process as
-numprocs=%(ENV_DOCKER_MAUTIC_WORKERS_CONSUME_FAILED)s           ; Number of processes to run (read from environment variable)
-startsecs=5                                                     ; Wait 5 second after process start
-autostart=true                                                  ; Automatically start the process when supervisord starts
-autorestart=true                                                ; Automatically restart the process if it exits
-startretries=3                                                  ; Number of times to retry starting the process
-process_name=%(program_name)s_%(process_num)02d                 ; Name of the process (includes program name and process number)
-stdout_logfile=/var/log/messenger-consume-failed.log            ; Dedicated log file
-stdout_logfile_maxbytes=10MB                                    ; Limit log file size
-stdout_logfile_backups=10                                       ; Rotate log files
-stderr_logfile=/var/log/messenger-consume-failed-error.log      ; Separate error log
-stderr_logfile_maxbytes=10MB                                    ; Limit error log file size
-stderr_logfile_backups=10                                       ; Rotate error log files    
-;resource_limits:cpu=20                                         ; Limit CPU usage to 20% (example)
-;resource_limits:memory=200MB                                   ; Limit memory usage to 200MB (example)
-redirect_stderr=false                                           ; Don't redirect stderr to stdout
+command=php /var/www/html/bin/console messenger:consume failed -vv
+user=www-data
+numprocs=%(ENV_DOCKER_MAUTIC_WORKERS_CONSUME_FAILED)s
+startsecs=0
+autostart=true
+autorestart=true
+startretries=10
+process_name=%(program_name)s_%(process_num)02d
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+redirect_stderr=true


### PR DESCRIPTION
Changes in the RabbitMQ example:

1. Inclusion of Mailer URL for specific use by Workers (with MailGun example)

2. Additional script as an entrypoint for the mautic_worker container to create the vhosts that will be used by Mautic

3. Supervisord configuration file for increased resilience and best practices

4. Update of the Mautic image to 5.2.3